### PR TITLE
chained guzzle exception to TokenResponseException

### DIFF
--- a/src/OAuth/Common/Http/Client/GuzzleClient.php
+++ b/src/OAuth/Common/Http/Client/GuzzleClient.php
@@ -95,9 +95,9 @@ class GuzzleClient extends AbstractClient
                 throw new TokenResponseException('Server returned HTTP response code '.$response->getStatusCode());
             }
         } catch (BadResponseException $e) {
-            throw new TokenResponseException('Guzzle client error: ' . $e->getMessage());
+            throw new TokenResponseException('Guzzle client error: ' . $e->getMessage(), null, $e);
         } catch (CurlException $e) {
-            throw new TokenResponseException('Guzzle client error: ' . $e->getMessage());
+            throw new TokenResponseException('Guzzle client error: ' . $e->getMessage(), null, $e);
         }
 
         return $response->getBody(true);


### PR DESCRIPTION
made the guzzle and curl exceptions on retrieveResponse chain on retrieveResponse. This is useful for debugging the response of external api endpoints to your validated requests

**This PR requires php >5.3**

example:
```
try {
	$response = $service->request($uri);
	return Response::make($response)->header('Content-Type', 'application/json');
} catch (OAuth\Common\Http\Exception\TokenResponseException $e) {
	if ('Guzzle\Http\Exception\ClientErrorResponseException' === get_class($e->getPrevious())) {
		$response = $e->getPrevious()->getResponse()->json();
		return Response::json($response,400);
	}
	return Response::json(array("reason" => $e),400);
}
````